### PR TITLE
derive Debug on all structs and enums

### DIFF
--- a/src/ac_adapter.rs
+++ b/src/ac_adapter.rs
@@ -13,6 +13,7 @@ pub enum Status {
 }
 
 /// Information about AC adapters plugged into the system.
+#[derive(Debug)]
 pub struct ACAdapterInfo {
     /// The name used by ACPI to refer to the adapter.
     pub name: String,

--- a/src/battery.rs
+++ b/src/battery.rs
@@ -5,7 +5,7 @@ use std::time;
 use crate::utils::*;
 
 /// Different possible battery charging states.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum ChargingState {
     Charging,
     Discharging,
@@ -13,6 +13,7 @@ pub enum ChargingState {
 }
 
 /// Metadata pertaining to a battery.
+#[derive(Debug)]
 pub struct BatteryInfo {
     /// The name used by ACPI to refer to the device.
     pub name: String,

--- a/src/cooling.rs
+++ b/src/cooling.rs
@@ -4,7 +4,7 @@ use std::path;
 use crate::utils::*;
 
 /// State information on a cooling device's activity.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct CoolingStatus {
     /// The current level of the cooling device relative to the max_state
     pub current_state: i32,
@@ -13,6 +13,7 @@ pub struct CoolingStatus {
 }
 
 /// Information about cooling devices available to the system.
+#[derive(Debug)]
 pub struct CoolingDevice {
     /// The name used by ACPI to refer to the device.
     pub name: String,

--- a/src/thermal_zone.rs
+++ b/src/thermal_zone.rs
@@ -4,7 +4,7 @@ use std::path;
 use crate::utils::*;
 
 /// An enumeration of the units with which the applications is displaying temperature data.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum Units {
     Fahrenheit,
     Celsius,
@@ -12,6 +12,7 @@ pub enum Units {
 }
 
 /// Information about the temperature at which the system takes action to reduce the temperature of a thermal zone.
+#[derive(Debug)]
 pub struct TripPoint {
     /// A numerical identifier for the trip point.
     pub number: u8,
@@ -24,6 +25,7 @@ pub struct TripPoint {
 }
 
 /// Information about a zone monitored by a temperature sensor.
+#[derive(Debug)]
 pub struct ThermalSensor {
     /// The name used by ACPI to refer to the sensor.
     pub name: String,


### PR DESCRIPTION
I think it might be better if you derive the Debug trait on structs/enums like ChargingState, BatteryInfo, and etc, so that you can print their values with `{:#?}`. Otherwise, if you wanted to debug-print structs and enums not implementing Debug from a library like acpi_client, you'd have to create a newtype wrapper for each:
```rust
pub struct DebugBatteryInfo(BatteryInfo);

impl fmt::Debug for DebugBatteryInfo {
    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
        f.debug_struct("BatteryInfo")
            .field("name", &self.0.name)
            .field("remaining_capacity", &self.0.remaining_capacity)
            .field("present_rate", &self.0.present_rate)
            .field("voltage", &self.0.voltage)
            .field("design_capacity", &self.0.design_capacity)
            .field("last_capacity", &self.0.last_capacity)
            .field("time_remaining", &self.0.time_remaining) // Duration implements Debug
            .field("percentage", &self.0.percentage)
            .field("state", &DebugChargingState(self.0.state)) // Wrap ChargingState for Debug
            .finish()
    }
}
```