### PR TITLE
feat: added new charging state "not charging"

### DIFF
--- a/src/battery.rs
+++ b/src/battery.rs
@@ -10,6 +10,7 @@ pub enum ChargingState {
     Charging,
     Discharging,
     Full,
+    NotCharging,
 }
 
 /// Metadata pertaining to a battery.
@@ -201,6 +202,8 @@ fn parse_state_from_str(state_str: String) -> Result<ChargingState, AcpiClientEr
         Ok(ChargingState::Discharging)
     } else if state_str == "full" {
         Ok(ChargingState::Full)
+    } else if state_str == "not charging" {
+        Ok(ChargingState::NotCharging)
     } else {
         Err(AcpiClientError::InvalidInput(std::io::Error::new(
             std::io::ErrorKind::Other,


### PR DESCRIPTION
Power-saving programs like TLP has the feature to stop charging the laptop battery when it reaches a certain threshold, making the charging state "not charging". And acpi_client throws an error if the charging state is "not charging" upon running `BatteryInfo::new(&path)`. So I added support for the "not charging" charging state.